### PR TITLE
add button for feature combinations

### DIFF
--- a/grambank/templates/parameter/detail_html.mako
+++ b/grambank/templates/parameter/detail_html.mako
@@ -1,5 +1,7 @@
 <%inherit file="../${context.get('request').registry.settings.get('clld.app_template', 'app.mako')}"/>
 <%namespace name="util" file="../util.mako"/>
+<% from clld.db.meta import DBSession %>
+<% from grambank import models %>
 
 <%! active_menu_item = "parameters" %>
 <%block name="title">Feature ${ctx.id}: ${ctx.name}</%block>
@@ -58,6 +60,25 @@
 ${u.process_markdown(ctx.description, req)|n}
 
 <br style="clear: right"/>
+
+<div class="well well-small">
+    <p>
+        You may combine this variable with a different variable by selecting on in the list below
+        and clicking "Submit".
+    </p>
+    <form action="${request.route_url('select_combination')}"
+          method="get"
+          class="form-inline">
+        <input type="hidden" name="parameters" value="${ctx.id}"/>
+        <select id="pa" name="parameters">
+            <label for="pa">Variable</label>
+            % for param in DBSession.query(models.Parameter).filter(models.Parameter.pk != ctx.pk):
+                <option value="${param.id}">${param.id} ${param.name}</option>
+            % endfor
+        </select>
+        <button class="btn" type="submit">Submit</button>
+    </form>
+</div>
 
 <h3 id="map-container">
     Map

--- a/grambank/templates/parameter/detail_html.mako
+++ b/grambank/templates/parameter/detail_html.mako
@@ -1,6 +1,5 @@
 <%inherit file="../${context.get('request').registry.settings.get('clld.app_template', 'app.mako')}"/>
 <%namespace name="util" file="../util.mako"/>
-<% from clld.db.meta import DBSession %>
 <% from grambank import models %>
 
 <%! active_menu_item = "parameters" %>
@@ -72,7 +71,7 @@ ${u.process_markdown(ctx.description, req)|n}
         <input type="hidden" name="parameters" value="${ctx.id}"/>
         <select id="pa" name="parameters">
             <label for="pa">Variable</label>
-            % for param in DBSession.query(models.Parameter).filter(models.Parameter.pk != ctx.pk):
+            % for param in request.db.query(models.Parameter).filter(models.Parameter.pk != ctx.pk):
                 <option value="${param.id}">${param.id} ${param.name}</option>
             % endfor
         </select>


### PR DESCRIPTION
The button exists now (see picture -- I haven't deployed it yet).

![grambank-combine-features](https://user-images.githubusercontent.com/1862047/223100430-88994db3-0602-4c78-b412-be39735dc4c1.png)

@HedvigS I'm not entirely sure where the button should actually go on the page.  For now I put it at the bottom of the description section (right above the map).  So, if you want me to move it somewhere else, just tell me.

Also, which features should be combinable here?  All of them or only the ones listed in *Related features* (this branch does the former rn)?

@xrotwang The code in the template feels a bit weird (like, the part where I import DBSession into the template).  Is there a more idiomatic way to do this that I'm missing?

