### PR TITLE
Link feature to families

### DIFF
--- a/grambank/__init__.py
+++ b/grambank/__init__.py
@@ -66,7 +66,7 @@ def combine_feature_with_family(ctx, req):
         raise httpexceptions.HTTPFound(
             req.route_url('family', id=family_id, _query=query))
     else:
-        raise httpexceptions.HTTPNotFound
+        raise httpexceptions.HTTPNotFound()
 
 
 def main(global_config, **settings):

--- a/grambank/__init__.py
+++ b/grambank/__init__.py
@@ -1,6 +1,7 @@
 import functools
 
 from pyramid.config import Configurator
+from pyramid import httpexceptions
 from sqlalchemy.orm import joinedload
 
 from clld.interfaces import (
@@ -57,6 +58,17 @@ def link_attrs(req, obj, **kw):
     return kw
 
 
+def combine_feature_with_family(ctx, req):
+    if 'feature' in req.params and 'family' in req.params:
+        feature_id = req.params.get('feature')
+        family_id = req.params.get('family')
+        query = {'feature': feature_id}
+        raise httpexceptions.HTTPFound(
+            req.route_url('family', id=family_id, _query=query))
+    else:
+        raise httpexceptions.HTTPNotFound
+
+
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
@@ -66,6 +78,10 @@ def main(global_config, **settings):
     config.include('clld_phylogeny_plugin')
     config.register_datatable('familys', datatables.Families)
     config.add_route_and_view('faq', '/faq', lambda *args, **kw: {}, renderer='faq.mako')
+    config.add_route_and_view(
+        'combine_feature_with_family',
+        '/_combine_feature_with_family',
+        combine_feature_with_family)
 
     config.registry.registerUtility(GrambankCtxFactoryQuery(), ICtxFactoryQuery)
     config.registry.registerUtility(GrambankMapMarker(), IMapMarker)

--- a/grambank/templates/family/detail_html.mako
+++ b/grambank/templates/family/detail_html.mako
@@ -43,11 +43,12 @@
         <div id="feature-container" class="${'alert alert-info' if feature else 'well well-small'}">
             <p>
                 To display the datapoints for a particular feature on the map and on the
-                classification tree, select the feauture then click "submit".
+                classification tree, select the feature then click "submit".
             </p>
-            <form action="${request.route_url('family', id=ctx.id)}"
+            <form action="${request.route_url('combine_feature_with_family')}"
                   method="get"
                   class="form-inline">
+                <input type="hidden" name="family" value="${ctx.id}" />
                 <select id="ps" name="feature" class="input-xxlarge">
                     <label for="ps">Feature</label>
                     % for f in features:

--- a/grambank/templates/family/detail_html.mako
+++ b/grambank/templates/family/detail_html.mako
@@ -11,6 +11,7 @@
 <%block name="title">Family ${ctx.name}</%block>
 
 <%! from sqlalchemy.orm import joinedload %>
+<%! import sqlalchemy %>
 
 <ul class="nav nav-pills" style="float: right">
     <li class="">
@@ -51,10 +52,20 @@
                 <input type="hidden" name="family" value="${ctx.id}" />
                 <select id="ps" name="feature" class="input-xxlarge">
                     <label for="ps">Feature</label>
-                    % for f in features:
-                        <option value="${f.id}"${' selected="selected"' if feature and feature.id == f.id else ''}>
-                            ${f.id} ${f.name}
-                        </option>
+                    ## XXX: This can probably be expressed in SQLAlchemy dot-notation.
+                    <%! query = sqlalchemy.text('''
+                        SELECT DISTINCT parameter.id, parameter.name
+                        FROM value
+                        JOIN valueset ON valueset.pk = value.valueset_pk
+                        JOIN parameter ON parameter.pk = valueset.parameter_pk
+                        JOIN grambanklanguage ON grambanklanguage.pk = valueset.language_pk
+                        WHERE grambanklanguage.family_pk = :family_pk
+                        ORDER BY parameter.id;''')
+                    %>
+                    % for feature_id, feature_name in request.db.execute(query, {'family_pk': ctx.pk}):
+                      <option value="${feature_id}"${' selected="selected"' if feature and feature.id == feature_id else ''}>
+                         ${feature_id} ${feature_name}
+                      </option>
                     % endfor
                 </select>
                 <button class="btn" type="submit">Submit</button>

--- a/grambank/templates/parameter/detail_html.mako
+++ b/grambank/templates/parameter/detail_html.mako
@@ -1,5 +1,6 @@
 <%inherit file="../${context.get('request').registry.settings.get('clld.app_template', 'app.mako')}"/>
 <%namespace name="util" file="../util.mako"/>
+<% from clld_glottologfamily_plugin.models import Family %>
 <% from grambank import models %>
 
 <%! active_menu_item = "parameters" %>
@@ -59,6 +60,25 @@
 ${u.process_markdown(ctx.description, req)|n}
 
 <br style="clear: right"/>
+
+<div class="well well-small">
+    <p>
+        To display the datapoints for a particular language family on the map
+        and on the classification tree, select the feature then click "submit".
+    </p>
+    <form action="${request.route_url('combine_feature_with_family')}"
+          method="get"
+          class="form-inline">
+        <input type="hidden" name="feature" value="${ctx.id}" />
+        <select id="fs" name="family">
+            <label for="fs">Family</label>
+            % for f in request.db.query(Family).order_by(Family.name):
+              <option value="${f.id}">${f.name}</option>
+            % endfor
+        </select>
+        <button class="btn" type="submit">Submit</button>
+    </form>
+</div>
 
 <div class="well well-small">
     <p>

--- a/grambank/templates/parameter/detail_html.mako
+++ b/grambank/templates/parameter/detail_html.mako
@@ -1,6 +1,5 @@
 <%inherit file="../${context.get('request').registry.settings.get('clld.app_template', 'app.mako')}"/>
 <%namespace name="util" file="../util.mako"/>
-<% from clld_glottologfamily_plugin.models import Family %>
 <% from grambank import models %>
 
 <%! active_menu_item = "parameters" %>

--- a/grambank/templates/parameter/detail_html.mako
+++ b/grambank/templates/parameter/detail_html.mako
@@ -66,7 +66,7 @@ ${u.process_markdown(ctx.description, req)|n}
 <div class="well well-small">
     <p>
         To display the datapoints for a particular language family on the map
-        and on the classification tree, select the feature then click "submit".
+        and on the classification tree, select the family then click "submit".
     </p>
     <form action="${request.route_url('combine_feature_with_family')}"
           method="get"


### PR DESCRIPTION
 * Added box to feature page that lets you choose a language family (cf. #12).
 * Adapted the family page so it uses the same code.
 * Filtered the list, so the box only shows family--feature combinations that
   actually exist (example of a non-existing combination:
   https://grambank.clld.org/familys/kres1240?feature=GB432#0/0/0)

![family-chooser](https://user-images.githubusercontent.com/1862047/224303086-955ee262-6147-4ab5-9745-8424a0f36bdd.png)
