### PR TITLE
Prepare feature regex for feature binarisation

### DIFF
--- a/grambank/util.py
+++ b/grambank/util.py
@@ -73,7 +73,7 @@ def process_markdown(text, req, section=None):
             in_section = True
 
     html = markdown('\n'.join(md), extensions=['tables', 'fenced_code', 'toc'])
-    wiki_url_pattern = re.compile('https://github.com/grambank/[gG]rambank/wiki/(?P<id>GB[0-9]{3})')
+    wiki_url_pattern = re.compile('https://github.com/grambank/[gG]rambank/wiki/(?P<id>GB[0-9]{3}[a-z]?)')
     html = wiki_url_pattern.sub(lambda m: req.route_url('parameter', id=m.group('id')), html)
     return html.replace('<code>', '').replace('</code>', '').replace('<table>', '<table class="table table-nonfluid">')
 


### PR DESCRIPTION
Preparing the webapp for the introduction of GB123a-style feature IDs.

It's a very short patch.  Apparently there's literally just exactly *one* regex in this entire project (for whatever reason I find that weird and uncanny… (<_<)" ).