### PR TITLE
add value counts to map reloader

### DIFF
--- a/grambank/static/project.css
+++ b/grambank/static/project.css
@@ -126,7 +126,6 @@ a:hover {
 }
 
 .alert-info td {
-    /* #3a87ad */
     border-top: 1px solid #aed5e8;
 }
 

--- a/grambank/static/project.css
+++ b/grambank/static/project.css
@@ -125,6 +125,11 @@ a:hover {
         background-image: none;
 }
 
+.alert-info td {
+    /* #3a87ad */
+    border-top: 1px solid #aed5e8;
+}
+
 div.error {
     background-color: #f5e5e5;
     border: 1px solid #e35e61;

--- a/grambank/templates/parameter/detail_html.mako
+++ b/grambank/templates/parameter/detail_html.mako
@@ -84,13 +84,14 @@ ${u.process_markdown(ctx.description, req)|n}
 <div class="alert alert-info" style="float: right">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     Customize map markers:
-    <table class="table-condensed">
+    <table class="table table-condensed">
         <tbody>
         % for de in ctx.domain:
         <tr>
             <td>${util.coloris_icon_picker(u.icon_from_req(de, req))|n}</td>
             <td>${de.name}</td>
             <td>${de.description}</td>
+            <td class="right">${len(de.values)}</td>
         </tr>
         % endfor
         </tbody>


### PR DESCRIPTION
I added the counts for features values to the map icon customiser like in WALS (although Grambank has this table in a far less prominent spot than WALS):

![grambank-feature-value-count-table](https://github.com/clld/grambank/assets/1862047/794af53f-0340-44db-99de-338dedadb4cb)
