### PR TITLE
'Languages and dialects' in box on front page

### DIFF
--- a/grambank/templates/dataset/detail_html.mako
+++ b/grambank/templates/dataset/detail_html.mako
@@ -10,7 +10,7 @@
         <table class="table table-condensed">
             <tbody>
             <tr>
-                <th>Languages</th>
+                <th>Languages and dialects</th>
                 <td class="right">${'{:,}'.format(stats['language'])}</td>
             </tr>
             <tr>


### PR DESCRIPTION
Preview:

![preview](https://github.com/clld/grambank/assets/1862047/52d47f97-6b7b-4bea-b341-1be29ebdcc3b)

The line breaks don't look great but I don't see a good way to fix those…  There's exactly *one* long line in column 1 and *one* long line in column 2. (\<\_\<)"