### PR TITLE
Fixed incremental search by Feature ID

### DIFF
--- a/grambank/datatables.py
+++ b/grambank/datatables.py
@@ -290,7 +290,7 @@ class Datapoints(Values):
             ]
         elif self.language:
             cols = [
-                IdCol(
+                FeatureIdCol(
                     self, 'Feature Id',
                     sClass='left', model_col=common.Parameter.id,
                     get_object=lambda i: i.valueset.parameter),
@@ -308,7 +308,7 @@ class Datapoints(Values):
             ]
             if not self.feature:
                 cols.extend([
-                    IdCol(
+                    FeatureIdCol(
                         self, 'Feature Id',
                         sClass='left', model_col=common.Parameter.id,
                         get_object=lambda i: i.valueset.parameter),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
On both the *language* and *language family* pages, filtering the data by Feature ID only worked when the search query matched the Feature ID *exactly* (e.g. `GB020`).  This patch fixes that.

Also, I snuck in a stub *pyproject.toml* to shut up pip.
